### PR TITLE
Add video.details().liveUrl()

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,11 @@ video.downloadAsync(videoFormats.get(0), outputDir, new OnYoutubeDownloadListene
 Future<File> future = video.downloadAsync(format, outputDir);
 File file = future.get(5, TimeUnit.SECONDS);
 
+// live videos and streams
+if (video.details().isLive()) {
+    System.out.println("Live Stream HLS URL: " + video.details().liveUrl());
+}
+
 ```
 
 Include

--- a/pom.xml
+++ b/pom.xml
@@ -65,6 +65,13 @@
                 </executions>
 
             </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>2.22.0</version>
+            </plugin>
+
         </plugins>
     </build>
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.github.ikiulian</groupId>
     <artifactId>java-youtube-downloader</artifactId>
-    <version>2.1.3</version>
+    <version>2.1.4</version>
 
     <name>Java youtube video and audio downloader</name>
     <description>Easy download youtube videos and audio with java</description>

--- a/src/main/java/com/github/kiulian/downloader/YoutubeDownloader.java
+++ b/src/main/java/com/github/kiulian/downloader/YoutubeDownloader.java
@@ -68,10 +68,6 @@ public class YoutubeDownloader {
 
         List<Format> formats = parser.parseFormats(ytPlayerConfig);
 
-        if (videoDetails.isLive()) {
-            videoDetails.setLiveUrl(parser.getLiveHLSUrl(ytPlayerConfig));
-        }
-
         return new YoutubeVideo(videoDetails, formats);
     }
 }

--- a/src/main/java/com/github/kiulian/downloader/YoutubeDownloader.java
+++ b/src/main/java/com/github/kiulian/downloader/YoutubeDownloader.java
@@ -67,6 +67,11 @@ public class YoutubeDownloader {
         VideoDetails videoDetails = parser.getVideoDetails(ytPlayerConfig);
 
         List<Format> formats = parser.parseFormats(ytPlayerConfig);
+
+        if (videoDetails.isLive()) {
+            videoDetails.setLiveUrl(parser.getLiveHLSUrl(ytPlayerConfig));
+        }
+
         return new YoutubeVideo(videoDetails, formats);
     }
 }

--- a/src/main/java/com/github/kiulian/downloader/YoutubeDownloader.java
+++ b/src/main/java/com/github/kiulian/downloader/YoutubeDownloader.java
@@ -67,7 +67,6 @@ public class YoutubeDownloader {
         VideoDetails videoDetails = parser.getVideoDetails(ytPlayerConfig);
 
         List<Format> formats = parser.parseFormats(ytPlayerConfig);
-
         return new YoutubeVideo(videoDetails, formats);
     }
 }

--- a/src/main/java/com/github/kiulian/downloader/model/VideoDetails.java
+++ b/src/main/java/com/github/kiulian/downloader/model/VideoDetails.java
@@ -40,6 +40,7 @@ public class VideoDetails {
     private int averageRating;
     private boolean isLiveContent;
     private boolean isLive;
+    private String liveUrl;
 
     public VideoDetails() {
     }
@@ -108,4 +109,11 @@ public class VideoDetails {
         return isLiveContent;
     }
 
+    public String liveUrl() {
+        return liveUrl;
+    }
+
+    public void setLiveUrl(String url) {
+        liveUrl = url;
+    }
 }

--- a/src/main/java/com/github/kiulian/downloader/model/VideoDetails.java
+++ b/src/main/java/com/github/kiulian/downloader/model/VideoDetails.java
@@ -45,7 +45,7 @@ public class VideoDetails {
     public VideoDetails() {
     }
 
-    public VideoDetails(JSONObject json) {
+    public VideoDetails(JSONObject json, String liveHLSUrl) {
         videoId = json.getString("videoId");
         title = json.getString("title");
         lengthSeconds = json.getIntValue("lengthSeconds");
@@ -63,6 +63,7 @@ public class VideoDetails {
         author = json.getString("author");
         isLiveContent = json.getBooleanValue("isLiveContent");
         isLive = json.getBooleanValue("isLive");
+        liveUrl = liveHLSUrl;
     }
 
     public String videoId() {
@@ -113,7 +114,4 @@ public class VideoDetails {
         return liveUrl;
     }
 
-    public void setLiveUrl(String url) {
-        liveUrl = url;
-    }
 }

--- a/src/main/java/com/github/kiulian/downloader/parser/DefaultParser.java
+++ b/src/main/java/com/github/kiulian/downloader/parser/DefaultParser.java
@@ -81,12 +81,22 @@ public class DefaultParser implements Parser {
     }
 
     @Override
-    public VideoDetails getVideoDetails(JSONObject config) {
+    public VideoDetails getVideoDetails(JSONObject config) throws YoutubeException.BadPageException {
         JSONObject args = config.getJSONObject("args");
         JSONObject playerResponse = args.getJSONObject("player_response");
 
-        if (playerResponse.containsKey("videoDetails"))
-            return new VideoDetails(playerResponse.getJSONObject("videoDetails"));
+        if (playerResponse.containsKey("videoDetails")) {
+            JSONObject videoDetails = playerResponse.getJSONObject("videoDetails");
+            String liveHLSUrl = null;
+            if(videoDetails.getBooleanValue("isLive")) {
+                if (playerResponse.containsKey("streamingData")) {
+                    liveHLSUrl = playerResponse.getJSONObject("streamingData").getString("hlsManifestUrl");
+                }
+            }
+            return new VideoDetails(videoDetails, liveHLSUrl);
+        }
+
+
 
         return new VideoDetails();
     }
@@ -172,25 +182,5 @@ public class DefaultParser implements Parser {
             return new VideoFormat(json);
 
         return new AudioFormat(json);
-    }
-
-    @Override
-    public String getLiveHLSUrl(JSONObject config) throws YoutubeException {
-        JSONObject args = config.getJSONObject("args");
-        JSONObject playerResponse = args.getJSONObject("player_response");
-
-        if (!playerResponse.containsKey("streamingData")) {
-            throw new YoutubeException.BadPageException("Streaming data not found");
-        }
-
-        JSONObject streamingData = playerResponse.getJSONObject("streamingData");
-
-        if (streamingData.containsKey("hlsManifestUrl")) {
-            return streamingData.getString("hlsManifestUrl");
-        } else {
-            System.out.println("NOT FOUND");
-        }
-
-        return null;
     }
 }

--- a/src/main/java/com/github/kiulian/downloader/parser/DefaultParser.java
+++ b/src/main/java/com/github/kiulian/downloader/parser/DefaultParser.java
@@ -81,7 +81,7 @@ public class DefaultParser implements Parser {
     }
 
     @Override
-    public VideoDetails getVideoDetails(JSONObject config) throws YoutubeException.BadPageException {
+    public VideoDetails getVideoDetails(JSONObject config) {
         JSONObject args = config.getJSONObject("args");
         JSONObject playerResponse = args.getJSONObject("player_response");
 

--- a/src/main/java/com/github/kiulian/downloader/parser/DefaultParser.java
+++ b/src/main/java/com/github/kiulian/downloader/parser/DefaultParser.java
@@ -173,4 +173,24 @@ public class DefaultParser implements Parser {
 
         return new AudioFormat(json);
     }
+
+    @Override
+    public String getLiveHLSUrl(JSONObject config) throws YoutubeException {
+        JSONObject args = config.getJSONObject("args");
+        JSONObject playerResponse = args.getJSONObject("player_response");
+
+        if (!playerResponse.containsKey("streamingData")) {
+            throw new YoutubeException.BadPageException("Streaming data not found");
+        }
+
+        JSONObject streamingData = playerResponse.getJSONObject("streamingData");
+
+        if (streamingData.containsKey("hlsManifestUrl")) {
+            return streamingData.getString("hlsManifestUrl");
+        } else {
+            System.out.println("NOT FOUND");
+        }
+
+        return null;
+    }
 }

--- a/src/main/java/com/github/kiulian/downloader/parser/Parser.java
+++ b/src/main/java/com/github/kiulian/downloader/parser/Parser.java
@@ -38,11 +38,10 @@ public interface Parser {
 
     JSONObject getPlayerConfig(String htmlUrl) throws IOException, YoutubeException;
 
-    VideoDetails getVideoDetails(JSONObject config);
+    VideoDetails getVideoDetails(JSONObject config) throws YoutubeException.BadPageException;
 
     String getJsUrl(JSONObject config) throws YoutubeException;
 
     List<Format> parseFormats(JSONObject json) throws YoutubeException;
 
-    String getLiveHLSUrl(JSONObject config) throws YoutubeException;
 }

--- a/src/main/java/com/github/kiulian/downloader/parser/Parser.java
+++ b/src/main/java/com/github/kiulian/downloader/parser/Parser.java
@@ -43,4 +43,6 @@ public interface Parser {
     String getJsUrl(JSONObject config) throws YoutubeException;
 
     List<Format> parseFormats(JSONObject json) throws YoutubeException;
+
+    String getLiveHLSUrl(JSONObject config) throws YoutubeException;
 }

--- a/src/main/java/com/github/kiulian/downloader/parser/Parser.java
+++ b/src/main/java/com/github/kiulian/downloader/parser/Parser.java
@@ -38,7 +38,7 @@ public interface Parser {
 
     JSONObject getPlayerConfig(String htmlUrl) throws IOException, YoutubeException;
 
-    VideoDetails getVideoDetails(JSONObject config) throws YoutubeException.BadPageException;
+    VideoDetails getVideoDetails(JSONObject config);
 
     String getJsUrl(JSONObject config) throws YoutubeException;
 

--- a/src/test/java/com/github/kiulian/downloader/YoutubeLiveStream_Tests.java
+++ b/src/test/java/com/github/kiulian/downloader/YoutubeLiveStream_Tests.java
@@ -26,8 +26,7 @@ import static org.junit.jupiter.api.Assertions.*;
 class YoutubeLiveStream_Tests {
 
     private static final String LIVE_TEST_1 = "Zp9zBmwK4uQ";
-    private static final String WAS_LIVE_TEST_BUT_NOT_PUBLIC = "IsMZPeaD6k0";
-    private static final String WAS_LIVE_TEST_BUT_PUBLIC = "IsMZPeaD6k0"; //"Aymrnzianf0";
+    private static final String WAS_LIVE_TEST_BUT_PUBLIC = "IsMZPeaD6k0";
     @Test
     @DisplayName("We should be able to get the HLS Stream URL for a live stream")
     void getLiveStreamHLS_Success() {
@@ -81,6 +80,3 @@ class YoutubeLiveStream_Tests {
         }
     }
 }
-
-
-//https://manifest.googlevideo.com/api/manifest/hls_variant/expire/1591840371/ei/EjrhXtf6O8LK1wKVyoToDw/ip/188.192.58.15/id/IsMZPeaD6k0.1/source/yt_live_broadcast/requiressl/yes/hfr/1/playlist_duration/30/manifest_duration/30/maudio/1/gcr/de/vprv/1/go/1/keepalive/yes/dover/11/itag/0/playlist_type/DVR/sparams/expire%2Cei%2Cip%2Cid%2Csource%2Crequiressl%2Chfr%2Cplaylist_duration%2Cmanifest_duration%2Cmaudio%2Cgcr%2Cvprv%2Cgo%2Citag%2Cplaylist_type/sig/AOq0QJ8wRgIhAJNhfRbmfWN817cAC6Pe7BtGt5ROFXKA_6yyllMZIY56AiEAiNsrmugWn_IJTL07r_kI4vaZUCo9YjTjty8VkS8s-EE%3D/file/index.m3u8

--- a/src/test/java/com/github/kiulian/downloader/YoutubeLiveStream_Tests.java
+++ b/src/test/java/com/github/kiulian/downloader/YoutubeLiveStream_Tests.java
@@ -1,0 +1,86 @@
+package com.github.kiulian.downloader;
+
+import com.github.kiulian.downloader.model.Extension;
+import com.github.kiulian.downloader.model.VideoDetails;
+import com.github.kiulian.downloader.model.YoutubeVideo;
+import com.github.kiulian.downloader.model.formats.AudioVideoFormat;
+import com.github.kiulian.downloader.model.formats.Format;
+import com.github.kiulian.downloader.model.formats.VideoFormat;
+import com.github.kiulian.downloader.model.quality.AudioQuality;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.util.List;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+// TODO: add tests for different itags
+
+@DisplayName("Youtube downloader tests")
+class YoutubeLiveStream_Tests {
+
+    private static final String LIVE_TEST_1 = "Zp9zBmwK4uQ";
+    private static final String WAS_LIVE_TEST_BUT_NOT_PUBLIC = "IsMZPeaD6k0";
+    private static final String WAS_LIVE_TEST_BUT_PUBLIC = "IsMZPeaD6k0"; //"Aymrnzianf0";
+    @Test
+    @DisplayName("We should be able to get the HLS Stream URL for a live stream")
+    void getLiveStreamHLS_Success() {
+        YoutubeDownloader downloader = new YoutubeDownloader();
+
+        assertDoesNotThrow(() -> {
+            YoutubeVideo video = downloader.getVideo(LIVE_TEST_1);
+
+            VideoDetails details = video.details();
+            assertEquals(LIVE_TEST_1, details.videoId(), "videoId should be " + LIVE_TEST_1);
+
+            List<Format> formats = video.formats();
+            assertFalse(formats.isEmpty(), "formats should not be empty");
+            assertTrue(video.details().isLive(), "this should be a live video");
+            assertNotNull(video.details().liveUrl(), "there should be a live video url");
+            assertTrue(isReachable(video.details().liveUrl()), "url should be reachable");
+        });
+    }
+
+    @Test
+    @DisplayName("We should be able to get formats for a video that was live")
+    void getWasLiveFormats_Success() {
+        YoutubeDownloader downloader = new YoutubeDownloader();
+
+        assertDoesNotThrow(() -> {
+            YoutubeVideo video = downloader.getVideo(WAS_LIVE_TEST_BUT_PUBLIC);
+
+            VideoDetails details = video.details();
+            assertEquals(WAS_LIVE_TEST_BUT_PUBLIC, details.videoId(), "videoId should be " + WAS_LIVE_TEST_BUT_PUBLIC);
+            assertTrue(details.isLiveContent(), "videoId was live ");
+            assertFalse(details.thumbnails().isEmpty(), "thumbnails should be not empty");
+            assertNotEquals(0, details.lengthSeconds(), "length should not be 0");
+            assertNotEquals(0, details.viewCount(), "viewCount should not be 0");
+
+            List<Format> formats = video.formats();
+            assertFalse(formats.isEmpty(), "formats should not be empty");
+
+        });
+    }
+
+    private static boolean isReachable(String url) {
+        try {
+            HttpURLConnection connection = (HttpURLConnection) new URL(url).openConnection();
+            connection.setConnectTimeout(1000);
+            connection.setReadTimeout(1000);
+            connection.setRequestMethod("HEAD");
+            int responseCode = connection.getResponseCode();
+            return (200 <= responseCode && responseCode <= 399);
+        } catch (IOException exception) {
+            return false;
+        }
+    }
+}
+
+
+//https://manifest.googlevideo.com/api/manifest/hls_variant/expire/1591840371/ei/EjrhXtf6O8LK1wKVyoToDw/ip/188.192.58.15/id/IsMZPeaD6k0.1/source/yt_live_broadcast/requiressl/yes/hfr/1/playlist_duration/30/manifest_duration/30/maudio/1/gcr/de/vprv/1/go/1/keepalive/yes/dover/11/itag/0/playlist_type/DVR/sparams/expire%2Cei%2Cip%2Cid%2Csource%2Crequiressl%2Chfr%2Cplaylist_duration%2Cmanifest_duration%2Cmaudio%2Cgcr%2Cvprv%2Cgo%2Citag%2Cplaylist_type/sig/AOq0QJ8wRgIhAJNhfRbmfWN817cAC6Pe7BtGt5ROFXKA_6yyllMZIY56AiEAiNsrmugWn_IJTL07r_kI4vaZUCo9YjTjty8VkS8s-EE%3D/file/index.m3u8

--- a/src/test/java/com/github/kiulian/downloader/YoutubeLiveStream_Tests.java
+++ b/src/test/java/com/github/kiulian/downloader/YoutubeLiveStream_Tests.java
@@ -25,8 +25,8 @@ import static org.junit.jupiter.api.Assertions.*;
 @DisplayName("Youtube downloader tests")
 class YoutubeLiveStream_Tests {
 
-    private static final String LIVE_TEST_1 = "Zp9zBmwK4uQ";
-    private static final String WAS_LIVE_TEST_BUT_PUBLIC = "IsMZPeaD6k0";
+    private static final String LIVE_TEST_1 = "5qap5aO4i9A";
+    private static final String WAS_LIVE_TEST_BUT_PUBLIC = "boSGRDYm92E";
     @Test
     @DisplayName("We should be able to get the HLS Stream URL for a live stream")
     void getLiveStreamHLS_Success() {


### PR DESCRIPTION
It works for an upcoming stream, and stream that is live.

mvn -Dtest=YoutubeLiveStream_Tests test

HOWEVER, there is a period of time after a livestream is over that there are no formats available.  I will look into that, but for now this gets the live stream URL.