### PR TITLE
Faster downloads, audio formats parsing fix, Android compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,8 @@ hs_err_pid*
 # IDEA
 *.iml
 .idea
+
+# Eclipse
+.project
+.classpath
+.settings/

--- a/README.md
+++ b/README.md
@@ -168,12 +168,28 @@ Include
 ```gradle
 allprojects {
   repositories {
-  ...
-  maven { url 'https://jitpack.io' }
+    ...
+    maven { url 'https://jitpack.io' }
   }
 }
-  
+```
+```gradle 
 dependencies {
   implementation 'com.github.sealedtx:java-youtube-downloader:2.3.0'
+}
+```
+### Android
+
+```gradle
+android {
+  ...
+  compileOptions {
+    sourceCompatibility JavaVersion.VERSION_1_8
+    targetCompatibility JavaVersion.VERSION_1_8
+  }
+  // For Kotlin projects
+  kotlinOptions {
+    jvmTarget = "1.8"
+  }
 }
 ```

--- a/src/main/java/com/github/kiulian/downloader/YoutubeDownloader.java
+++ b/src/main/java/com/github/kiulian/downloader/YoutubeDownloader.java
@@ -73,7 +73,10 @@ public class YoutubeDownloader {
         List<Format> formats = parser.parseFormats(ytPlayerConfig);
 
         List<SubtitlesInfo> subtitlesInfo = parser.getSubtitlesInfoFromCaptions(ytPlayerConfig);
-        return new YoutubeVideo(videoDetails, formats, subtitlesInfo);
+        
+        String clientVersion = parser.getClientVersion(ytPlayerConfig);
+        
+        return new YoutubeVideo(videoDetails, formats, subtitlesInfo, clientVersion);
     }
 
     public YoutubePlaylist getPlaylist(String playlistId) throws YoutubeException {

--- a/src/main/java/com/github/kiulian/downloader/model/Filter.java
+++ b/src/main/java/com/github/kiulian/downloader/model/Filter.java
@@ -1,0 +1,41 @@
+package com.github.kiulian.downloader.model;
+
+import java.util.LinkedList;
+import java.util.List;
+
+/*-
+ * #
+ * Java youtube video and audio downloader
+ *
+ * Copyright (C) 2020 Igor Kiulian
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #
+ */
+
+
+@FunctionalInterface
+public interface Filter<T> {
+
+    boolean test(T element);
+
+    default List<T> select(List<T> elements) {
+        List<T> filtered = new LinkedList<>();
+        for (T element : elements) {
+            if (test(element)) {
+                filtered.add(element);
+            }
+        }
+        return filtered;
+    }
+}

--- a/src/main/java/com/github/kiulian/downloader/model/Utils.java
+++ b/src/main/java/com/github/kiulian/downloader/model/Utils.java
@@ -2,13 +2,15 @@ package com.github.kiulian.downloader.model;
 
 import com.github.kiulian.downloader.model.formats.Format;
 
+import java.io.Closeable;
 import java.io.File;
 import java.io.IOException;
 
-class Utils {
+public class Utils {
+
     private static final char[] ILLEGAL_FILENAME_CHARACTERS = {'/', '\n', '\r', '\t', '\0', '\f', '`', '?', '*', '\\', '<', '>', '|', '\"', ':'};
 
-    static String removeIllegalChars(String fileName) {
+    private static String removeIllegalChars(String fileName) {
         for (char c : ILLEGAL_FILENAME_CHARACTERS) {
             fileName = fileName.replace(c, '_');
         }
@@ -24,7 +26,7 @@ class Utils {
     }
 
     static File getOutputFile(final String name, Format format, File outDir, boolean overwrite) {
-        String fileName = name + "." + format.extension().value();
+        String fileName = removeIllegalChars(name) + "." + format.extension().value();
         File outputFile = new File(outDir, fileName);
 
         if (!overwrite) {
@@ -36,5 +38,13 @@ class Utils {
         }
 
         return outputFile;
+    }
+
+    public static void closeSilently(Closeable closeable) {
+        if (closeable != null) {
+            try {
+                closeable.close();
+            } catch (IOException ignored) {} 
+        }
     }
 }

--- a/src/main/java/com/github/kiulian/downloader/model/Utils.java
+++ b/src/main/java/com/github/kiulian/downloader/model/Utils.java
@@ -1,5 +1,26 @@
 package com.github.kiulian.downloader.model;
 
+/*-
+ * #
+ * Java youtube video and audio downloader
+ *
+ * Copyright (C) 2020 Igor Kiulian
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #
+ */
+
+
 import com.github.kiulian.downloader.model.formats.Format;
 
 import java.io.Closeable;

--- a/src/main/java/com/github/kiulian/downloader/model/YoutubeVideo.java
+++ b/src/main/java/com/github/kiulian/downloader/model/YoutubeVideo.java
@@ -38,8 +38,6 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.concurrent.Future;
 import java.util.concurrent.FutureTask;
-import java.util.function.Predicate;
-import java.util.stream.Collectors;
 
 import static com.github.kiulian.downloader.model.Utils.*;
 
@@ -72,8 +70,8 @@ public class YoutubeVideo {
         return subtitlesInfo;
     }
 
-    public List<Format> findFormats(Predicate<Format> filter) {
-        return formats.stream().filter(filter).collect(Collectors.toList());
+    public List<Format> findFormats(Filter<Format> filter) {
+        return filter.select(formats);
     }
 
     public Format findFormatByItag(int itag) {

--- a/src/main/java/com/github/kiulian/downloader/model/YoutubeVideo.java
+++ b/src/main/java/com/github/kiulian/downloader/model/YoutubeVideo.java
@@ -36,7 +36,6 @@ import java.net.URL;
 import java.net.URLConnection;
 import java.util.LinkedList;
 import java.util.List;
-import java.util.concurrent.Callable;
 import java.util.concurrent.Future;
 import java.util.concurrent.FutureTask;
 import java.util.function.Predicate;
@@ -46,14 +45,19 @@ import static com.github.kiulian.downloader.model.Utils.*;
 
 public class YoutubeVideo {
 
+    private static final int BUFFER_SIZE = 4096;
+    private static final int PART_LENGTH = 2 * 1024 * 1024;
+
     private VideoDetails videoDetails;
     private List<Format> formats;
     private List<SubtitlesInfo> subtitlesInfo;
+    private final String clientVersion;
 
-    public YoutubeVideo(VideoDetails videoDetails, List<Format> formats, List<SubtitlesInfo> subtitlesInfo) {
+    public YoutubeVideo(VideoDetails videoDetails, List<Format> formats, List<SubtitlesInfo> subtitlesInfo, String clientVersion) {
         this.videoDetails = videoDetails;
         this.formats = formats;
         this.subtitlesInfo = subtitlesInfo;
+        this.clientVersion = clientVersion;
     }
 
     public VideoDetails details() {
@@ -167,38 +171,9 @@ public class YoutubeVideo {
     }
 
     public File download(Format format, File outDir, String fileName, boolean overwrite) throws IOException, YoutubeException {
-        videoDetails.checkDownload();
+        File outputFile = initDownload(format, outDir, fileName, overwrite);
 
-        createOutDir(outDir);
-
-        File outputFile = getOutputFile(removeIllegalChars(fileName), format, outDir, overwrite);
-
-        URL url = new URL(format.url());
-        BufferedInputStream bis = null;
-        FileOutputStream fos = null;
-        try {
-            bis = new BufferedInputStream(url.openStream());
-            fos = new FileOutputStream(outputFile);
-            byte[] buffer = new byte[4096];
-            int count = 0;
-            while ((count = bis.read(buffer, 0, 4096)) != -1) {
-                fos.write(buffer, 0, count);
-            }
-        } finally {
-            if (bis != null) {
-                try {
-                    bis.close();
-                } catch (IOException ignored) {
-                }
-            }
-            if (fos != null) {
-                try {
-                    fos.close();
-                } catch (IOException ignored) {
-                }
-            }
-        }
-        return outputFile;
+        return basicDownload(format, outputFile, null);
     }
 
     public Future<File> downloadAsync(Format format, File outDir) throws YoutubeException.LiveVideoException, IOException {
@@ -210,16 +185,9 @@ public class YoutubeVideo {
     }
 
     public Future<File> downloadAsync(final Format format, final File outDir, final String fileName, final boolean overwrite) throws YoutubeException.LiveVideoException, IOException {
-        videoDetails.checkDownload();
+        File outputFile = initDownload(format, outDir, fileName, overwrite);
 
-        createOutDir(outDir);
-
-        FutureTask<File> future = new FutureTask<>(new Callable<File>() {
-            @Override
-            public File call() throws IOException, YoutubeException {
-                return download(format, outDir, fileName, overwrite);
-            }
-        });
+        FutureTask<File> future = new FutureTask<>(() -> basicDownload(format, outputFile, null));
 
         Thread thread = new Thread(future, "YtDownloader");
         thread.setDaemon(true);
@@ -236,60 +204,128 @@ public class YoutubeVideo {
     }
 
     public void downloadAsync(Format format, File outDir, String fileName, boolean overwrite, final OnYoutubeDownloadListener listener) throws IOException, YoutubeException {
+        File outputFile = initDownload(format, outDir, fileName, overwrite);
+
+        Thread thread = new Thread(() -> {
+            try {
+                basicDownload(format, outputFile, listener);
+            } catch (IOException ignored) {}
+        }, "YtDownloader");
+        thread.setDaemon(true);
+        thread.start();
+    }
+
+    private File initDownload(Format format, File outDir, String fileName, boolean overwrite) throws IOException, YoutubeException.LiveVideoException {
         videoDetails.checkDownload();
 
         createOutDir(outDir);
 
-        final File outputFile = getOutputFile(fileName, format, outDir, overwrite);
+        return getOutputFile(fileName, format, outDir, overwrite);
+    }
 
-        final URL url = new URL(format.url());
-        Thread thread = new Thread(new Runnable() {
-            @Override
-            public void run() {
-                BufferedInputStream bis = null;
-                FileOutputStream fos = null;
-                try {
-                    URLConnection urlConnection = url.openConnection();
-                    int contentLength = urlConnection.getContentLength();
+    private File basicDownload(Format format, File outputFile, OnYoutubeDownloadListener listener) throws IOException {
+        OutputStream os = null;
+        try {
+            os = new FileOutputStream(outputFile);
+            if (format.isAdaptive() && format.contentLength() != null) {
+                downloadByPart(format, os, listener);
+            } else {
+                downloadStraight(format, os, listener);
+            }
+            if (listener != null) {
+                listener.onFinished(outputFile);
+            }
+        } catch (IOException e) {
+            if (listener != null) {
+                listener.onError(e);
+            }
+            throw e;
+        } finally {
+            closeSilently(os);
+        }
+        return outputFile;
+    }
 
-                    bis = new BufferedInputStream(urlConnection.getInputStream());
-                    fos = new FileOutputStream(outputFile);
+    // Downloads the format in one single request
+    private void downloadStraight(Format format, OutputStream os, final OnYoutubeDownloadListener listener) throws IOException {
+        URLConnection urlConnection = new URL(format.url()).openConnection();
+        int contentLength = urlConnection.getContentLength();
+        
+        InputStream is = urlConnection.getInputStream();
+        
+        byte[] buffer = new byte[BUFFER_SIZE];
+        if (listener == null) {
+            copyAndCloseInput(is, os, buffer);
+        } else {
+            copyAndCloseInput(is, os, buffer, 0, contentLength, listener);
+        }
+    }
 
-                    double total = 0;
-                    byte[] buffer = new byte[4096];
-                    int count = 0;
-                    int progress = 0;
-                    while ((count = bis.read(buffer, 0, 4096)) != -1) {
-                        fos.write(buffer, 0, count);
-                        total += count;
-                        int newProgress = (int) ((total / contentLength) * 100);
-                        if (newProgress > progress) {
-                            progress = newProgress;
-                            listener.onDownloading(progress);
-                        }
-                    }
+    // Downloads the format part by part, with as many requests as needed
+    private void downloadByPart(Format format, OutputStream os, final OnYoutubeDownloadListener listener) throws IOException {
+        long done = 0;
+        int partNumber = 0;
 
-                    listener.onFinished(outputFile);
-                } catch (IOException e) {
-                    listener.onError(e);
-                } finally {
-                    if (bis != null) {
-                        try {
-                            bis.close();
-                        } catch (IOException ignored) {
-                        }
-                    }
-                    if (fos != null) {
-                        try {
-                            fos.close();
-                        } catch (IOException ignored) {
-                        }
-                    }
+        final String pathPrefix = "&cver=" + clientVersion + "&range=";
+        final long contentLength = format.contentLength();
+        byte[] buffer = new byte[BUFFER_SIZE];
+        
+        while (done < contentLength) {
+            long toRead = PART_LENGTH;
+            if (done + toRead > contentLength) {
+                toRead = (int) (contentLength - done);
+            }
+            
+            partNumber++;
+            String partUrl = format.url() + pathPrefix
+                    + done + "-" + (done + toRead - 1)    // range first-last byte positions
+                    + "&rn=" + partNumber;                // part number
+            URL url = new URL(partUrl);
+            InputStream is = url.openStream();
+            if (listener == null) {
+                done += copyAndCloseInput(is, os, buffer);
+            } else {
+                done += copyAndCloseInput(is, os, buffer, done, contentLength, listener);
+            }
+        }
+    }
+
+    // Copies as many bytes as possible then closes input stream
+    private static long copyAndCloseInput(InputStream is, OutputStream os, byte[] buffer, long offset, long totalLength, OnYoutubeDownloadListener listener) throws IOException {
+        long done = 0;
+        
+        try {
+            int read = 0;
+            long lastProgress = offset == 0 ? 0 : (offset * 100) / totalLength;
+            
+            while ((read = is.read(buffer)) != -1) {
+                os.write(buffer, 0, read);
+                done += read;
+                long progress = ((offset + done) * 100) / totalLength;
+                if (progress > lastProgress) {
+                    listener.onDownloading((int) progress);
+                    lastProgress = progress;
                 }
             }
-        }, "YtDownloader");
-        thread.setDaemon(true);
-        thread.start();
+        } finally {
+            closeSilently(is);
+        }
+        return done;
+    }
+
+    private static long copyAndCloseInput(InputStream is, OutputStream os, byte[] buffer) throws IOException {
+        long done = 0;
+        
+        try {
+            int count = 0;
+            while ((count = is.read(buffer)) != -1) {
+                os.write(buffer, 0, count);
+                done += count;
+            }
+        } finally {
+            closeSilently(is);
+        }
+        return done;
     }
 
 }

--- a/src/main/java/com/github/kiulian/downloader/model/formats/AudioFormat.java
+++ b/src/main/java/com/github/kiulian/downloader/model/formats/AudioFormat.java
@@ -30,8 +30,8 @@ public class AudioFormat extends Format {
     private final Integer audioSampleRate;
     private final AudioQuality audioQuality;
 
-    public AudioFormat(JSONObject json) {
-        super(json);
+    public AudioFormat(JSONObject json, boolean isAdaptive) {
+        super(json, isAdaptive);
         audioSampleRate = json.getInteger("audioSampleRate");
         averageBitrate = json.getInteger("averageBitrate");
 

--- a/src/main/java/com/github/kiulian/downloader/model/formats/AudioVideoFormat.java
+++ b/src/main/java/com/github/kiulian/downloader/model/formats/AudioVideoFormat.java
@@ -35,8 +35,8 @@ public class AudioVideoFormat extends Format {
     private final Integer height;
     private final VideoQuality videoQuality;
 
-    public AudioVideoFormat(JSONObject json) {
-        super(json);
+    public AudioVideoFormat(JSONObject json, boolean isAdaptive) {
+        super(json, isAdaptive);
         audioSampleRate = json.getInteger("audioSampleRate");
         averageBitrate = json.getInteger("averageBitrate");
         qualityLabel = json.getString("qualityLabel");

--- a/src/main/java/com/github/kiulian/downloader/model/formats/Format.java
+++ b/src/main/java/com/github/kiulian/downloader/model/formats/Format.java
@@ -31,6 +31,7 @@ public abstract class Format {
     public static final String VIDEO = "video";
     public static final String AUDIO_VIDEO = "audio/video";
 
+    private final boolean isAdaptive;
 
     protected final Itag itag;
     protected final String url;
@@ -41,7 +42,9 @@ public abstract class Format {
     protected final Long lastModified;
     protected final Long approxDurationMs;
 
-    protected Format(JSONObject json) {
+    protected Format(JSONObject json, boolean isAdaptive) {
+        this.isAdaptive = isAdaptive;
+        
         Itag itag;
         try {
             itag = Itag.valueOf("i" + json.getInteger("itag"));
@@ -81,6 +84,10 @@ public abstract class Format {
     }
 
     public abstract String type();
+
+    public boolean isAdaptive() {
+        return isAdaptive;
+    }
 
     public Itag itag() {
         return itag;

--- a/src/main/java/com/github/kiulian/downloader/model/formats/VideoFormat.java
+++ b/src/main/java/com/github/kiulian/downloader/model/formats/VideoFormat.java
@@ -32,8 +32,8 @@ public class VideoFormat extends Format {
     private final Integer height;
     private final VideoQuality videoQuality;
 
-    public VideoFormat(JSONObject json) {
-        super(json);
+    public VideoFormat(JSONObject json, boolean isAdaptive) {
+        super(json, isAdaptive);
         fps = json.getInteger("fps");
         qualityLabel = json.getString("qualityLabel");
         if (json.containsKey("size")) {

--- a/src/main/java/com/github/kiulian/downloader/model/playlist/YoutubePlaylist.java
+++ b/src/main/java/com/github/kiulian/downloader/model/playlist/YoutubePlaylist.java
@@ -22,8 +22,8 @@ package com.github.kiulian.downloader.model.playlist;
 
 
 import java.util.List;
-import java.util.function.Predicate;
-import java.util.stream.Collectors;
+
+import com.github.kiulian.downloader.model.Filter;
 
 public class YoutubePlaylist {
 
@@ -51,7 +51,7 @@ public class YoutubePlaylist {
         return null;
     }
 
-    public List<PlaylistVideoDetails> findVideos(Predicate<PlaylistVideoDetails> filter) {
-        return videos.stream().filter(filter).collect(Collectors.toList());
+    public List<PlaylistVideoDetails> findVideos(Filter<PlaylistVideoDetails> filter) {
+        return filter.select(videos);
     }
 }

--- a/src/main/java/com/github/kiulian/downloader/model/subtitles/Subtitles.java
+++ b/src/main/java/com/github/kiulian/downloader/model/subtitles/Subtitles.java
@@ -22,6 +22,7 @@ package com.github.kiulian.downloader.model.subtitles;
 
 import com.github.kiulian.downloader.YoutubeException;
 import com.github.kiulian.downloader.model.Extension;
+import com.github.kiulian.downloader.model.Utils;
 
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -91,12 +92,7 @@ public class Subtitles {
         } catch (IOException e) {
             throw new YoutubeException.SubtitlesException("Failed to download subtitle: " + e.getMessage());
         } finally {
-            if (br != null) {
-                try {
-                    br.close();
-                } catch (IOException ignored) {
-                }
-            }
+            Utils.closeSilently(br);
         }
 
         return result.toString();

--- a/src/main/java/com/github/kiulian/downloader/parser/DefaultParser.java
+++ b/src/main/java/com/github/kiulian/downloader/parser/DefaultParser.java
@@ -324,7 +324,7 @@ public class DefaultParser implements Parser {
             itag.setId(json.getIntValue("itag"));
         }
 
-        boolean hasVideo = itag.isVideo() || json.containsKey("quality");
+        boolean hasVideo = itag.isVideo() || json.containsKey("size") || json.containsKey("width");
         boolean hasAudio = itag.isAudio() || json.containsKey("audioQuality");
 
         if (hasVideo && hasAudio)

--- a/src/main/java/com/github/kiulian/downloader/parser/DefaultParser.java
+++ b/src/main/java/com/github/kiulian/downloader/parser/DefaultParser.java
@@ -83,6 +83,11 @@ public class DefaultParser implements Parser {
     }
 
     @Override
+    public String getClientVersion(JSONObject config) {
+        return getClientVersionFromContext(config.getJSONObject("args").getJSONObject("player_response").getJSONObject("responseContext"));
+    }
+
+    @Override
     public String getJsUrl(JSONObject config) throws YoutubeException {
         if (!config.containsKey("assets"))
             throw new YoutubeException.BadPageException("Could not extract js url: assets not found");
@@ -180,26 +185,14 @@ public class DefaultParser implements Parser {
         if (streamingData.containsKey("formats")) {
             jsonFormats.addAll(streamingData.getJSONArray("formats"));
         }
+        JSONArray jsonAdaptiveFormats = new JSONArray();
         if (streamingData.containsKey("adaptiveFormats")) {
-            jsonFormats.addAll(streamingData.getJSONArray("adaptiveFormats"));
+            jsonAdaptiveFormats.addAll(streamingData.getJSONArray("adaptiveFormats"));
         }
 
-        List<Format> formats = new ArrayList<>(jsonFormats.size());
-        for (int i = 0; i < jsonFormats.size(); i++) {
-            JSONObject json = jsonFormats.getJSONObject(i);
-            if ("FORMAT_STREAM_TYPE_OTF".equals(json.getString("type")))
-                continue; // unsupported otf formats which cause 404 not found
-            try {
-                Format format = parseFormat(json, config);
-                formats.add(format);
-            } catch (YoutubeException.CipherException e) {
-                throw e;
-            } catch (YoutubeException e) {
-                System.err.println("Error parsing format: " + json);
-            } catch (Exception e) {
-                e.printStackTrace();
-            }
-        }
+        List<Format> formats = new ArrayList<>(jsonFormats.size() + jsonAdaptiveFormats.size());
+        populateFormats(formats, jsonFormats, config, false);
+        populateFormats(formats, jsonAdaptiveFormats, config, true);
         return formats;
     }
 
@@ -263,11 +256,29 @@ public class DefaultParser implements Parser {
         } else {
             videos = new LinkedList<>();
         }
-        populatePlaylist(content, videos, getClientVersion(initialData));
+        populatePlaylist(content, videos, getClientVersionFromContext(initialData.getJSONObject("responseContext")));
         return videos;
     }
 
-    private Format parseFormat(JSONObject json, JSONObject config) throws YoutubeException {
+    private void populateFormats(List<Format> formats, JSONArray jsonFormats, JSONObject config, boolean isAdaptive) throws YoutubeException.CipherException {
+        for (int i = 0; i < jsonFormats.size(); i++) {
+            JSONObject json = jsonFormats.getJSONObject(i);
+            if ("FORMAT_STREAM_TYPE_OTF".equals(json.getString("type")))
+                continue; // unsupported otf formats which cause 404 not found
+            try {
+                Format format = parseFormat(json, config, isAdaptive);
+                formats.add(format);
+            } catch (YoutubeException.CipherException e) {
+                throw e;
+            } catch (YoutubeException e) {
+                System.err.println("Error parsing format: " + json);
+            } catch (Exception e) {
+                e.printStackTrace();
+            }
+        }
+    }
+
+    private Format parseFormat(JSONObject json, JSONObject config, boolean isAdaptive) throws YoutubeException {
         if (json.containsKey("signatureCipher")) {
             JSONObject jsonCipher = new JSONObject();
             String[] cipherData = json.getString("signatureCipher").replace("\\u0026", "&").split("&");
@@ -317,11 +328,11 @@ public class DefaultParser implements Parser {
         boolean hasAudio = itag.isAudio() || json.containsKey("audioQuality");
 
         if (hasVideo && hasAudio)
-            return new AudioVideoFormat(json);
+            return new AudioVideoFormat(json, isAdaptive);
         else if (hasVideo)
-            return new VideoFormat(json);
+            return new VideoFormat(json, isAdaptive);
         else if (hasAudio)
-            return new AudioFormat(json);
+            return new AudioFormat(json, isAdaptive);
 
         throw new YoutubeException.UnknownFormatException("unknown format with itag " + itag.id());
     }
@@ -332,7 +343,7 @@ public class DefaultParser implements Parser {
             videos.add(new PlaylistVideoDetails(contents.getJSONObject(i).getJSONObject("playlistVideoRenderer")));
         }
         if (content.containsKey("continuations")) {
-        	String continuation = content.getJSONArray("continuations")
+            String continuation = content.getJSONArray("continuations")
                     .getJSONObject(0)
                     .getJSONObject("nextContinuationData")
                     .getString("continuation");
@@ -364,9 +375,8 @@ public class DefaultParser implements Parser {
         }
     }
 
-    private String getClientVersion(JSONObject json) {
-        JSONArray trackingParams = json.getJSONObject("responseContext")
-                .getJSONArray("serviceTrackingParams");
+    private String getClientVersionFromContext(JSONObject context) {
+        JSONArray trackingParams = context.getJSONArray("serviceTrackingParams");
         if (trackingParams == null) {
             return "2.20200720.00.02";
         }

--- a/src/main/java/com/github/kiulian/downloader/parser/Parser.java
+++ b/src/main/java/com/github/kiulian/downloader/parser/Parser.java
@@ -42,6 +42,8 @@ public interface Parser {
 
     JSONObject getPlayerConfig(String htmlUrl) throws YoutubeException;
 
+    String getClientVersion(JSONObject config);
+
     VideoDetails getVideoDetails(JSONObject config);
 
     String getJsUrl(JSONObject config) throws YoutubeException;

--- a/src/test/java/com/github/kiulian/downloader/YoutubeDownloadSpeed_Tests.java
+++ b/src/test/java/com/github/kiulian/downloader/YoutubeDownloadSpeed_Tests.java
@@ -1,0 +1,146 @@
+package com.github.kiulian.downloader;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.io.*;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
+import org.junit.jupiter.api.*;
+
+import com.github.kiulian.downloader.model.YoutubeVideo;
+import com.github.kiulian.downloader.model.formats.Format;
+
+public class YoutubeDownloadSpeed_Tests extends TestUtils {
+    private static final File outDir = new File("videos");
+
+    // Zooming out from earth
+    private static final String ZOOM_OUT_ID = "DgqAAE9Aagc";
+
+    // Make download pauses obvious
+    private static final OnYoutubeDownloadListener listener = new OnYoutubeDownloadListener() {
+
+        @Override
+        public void onFinished(File file) {}
+        
+        @Override
+        public void onError(Throwable throwable) {}
+        
+        @Override
+        public void onDownloading(int progress) {
+            System.out.print(".");
+        }
+    };
+
+    protected YoutubeDownloader downloader;
+    private static Method straightMethod;
+    private static Method byPartMethod;
+
+    @BeforeAll
+    static void initReflectMethods() throws NoSuchMethodException, SecurityException {
+        straightMethod = YoutubeVideo.class.getDeclaredMethod("downloadStraight", Format.class, OutputStream.class, OnYoutubeDownloadListener.class);
+        straightMethod.setAccessible(true);
+        byPartMethod = YoutubeVideo.class.getDeclaredMethod("downloadByPart", Format.class, OutputStream.class, OnYoutubeDownloadListener.class);
+        byPartMethod.setAccessible(true);
+    }
+
+    @BeforeEach
+    void initDownloader() {
+        this.downloader = new YoutubeDownloader();
+        if (!outDir.isDirectory()) {
+            outDir.mkdirs();
+        }
+    }
+
+    @AfterEach
+    void cleanOutDir() {
+        if (outDir.isDirectory()) {
+            clean(outDir);
+        }
+    }
+
+    @Test
+    @DisplayName("download speed test should be successful")
+    void downloadSpeed_Success() {
+        
+        assertDoesNotThrow(() -> {
+            YoutubeVideo video = downloader.getVideo(ZOOM_OUT_ID);
+            testSpeed(video, 18);
+            testSpeed(video, 135);
+        });
+    }
+
+    private static void testSpeed(YoutubeVideo video, int itag) {
+        final Format format = video.findFormatByItag(itag);
+        assertNotNull(format, "findFormatByItag should return not null format");
+        
+        assertDoesNotThrow(() -> {
+            
+            long straightTime = System.currentTimeMillis();
+            File straightFile = download(video, format, false);
+            straightTime = System.currentTimeMillis() - straightTime;
+            System.out.println(" " + straightTime + "ms");
+            
+            long byPartTime = System.currentTimeMillis();
+            File byPartFile = download(video, format, true);
+            byPartTime = System.currentTimeMillis() - byPartTime;
+            System.out.println(" " + byPartTime + "ms");
+            
+            assertSameContent(straightFile, byPartFile);
+            
+            if (format.isAdaptive()) {
+                double ratio = (double) straightTime / (double) byPartTime;
+                assertTrue(byPartTime < straightTime, "Download by part should be faster for format: " + format.itag());
+                System.out.println("Download by part is " + String.format("%.2f", ratio) + " faster for format " + format.itag());
+            } else {
+                double ratio = (double) byPartTime / (double) straightTime;
+                assertTrue(byPartTime > straightTime, "Straight download should be faster for format: " + format.itag());
+                System.out.println("Straight download is " + String.format("%.2f", ratio) + " faster for format " + format.itag());
+            }
+        });
+    }
+
+    private static File download(YoutubeVideo video, Format format, boolean isByPart) throws IOException, YoutubeException {
+        System.out.print(isByPart ? "By part " : "Straight");
+        File outputFile = new File(outDir, video.details().title() + "_" + (isByPart ? "bypart" : "straight") + format.itag().id() + "." + format.extension().value());
+        try (OutputStream os = new FileOutputStream(outputFile)) {
+            Method method = isByPart ? byPartMethod : straightMethod;
+            method.setAccessible(true);
+            method.invoke(video, format, os, listener);
+            listener.onFinished(outputFile);
+            return outputFile;
+        } catch (SecurityException | IllegalAccessException | IllegalArgumentException e) {
+            fail(e);
+            return null;
+        } catch (InvocationTargetException e) {
+            listener.onError(e.getTargetException());
+            if (e.getTargetException() instanceof YoutubeException) {
+                throw (YoutubeException) e.getTargetException();
+            } else if (e.getTargetException() instanceof IOException) {
+                throw (IOException) e.getTargetException();
+            }
+            fail(e);
+            return null;
+        }
+    }
+
+    private static void assertSameContent(File left, File right) throws IOException {
+        assertEquals(left.length(), right.length());
+        
+        try (
+                InputStream leftIs = new FileInputStream(left);
+                InputStream rightIs = new FileInputStream(right);
+        ) {
+            int leftRead, rightRead;
+            byte[] leftBuf = new byte[4096];
+            byte[] rightBuf = new byte[4096];
+            
+            while ((leftRead = leftIs.read(leftBuf)) != -1) {
+                rightRead = rightIs.read(rightBuf);
+                // Local disk access, buffers should always be equal
+                assertEquals(leftRead, rightRead);
+                assertArrayEquals(leftBuf, rightBuf);
+            }
+        }
+    }
+}

--- a/src/test/java/com/github/kiulian/downloader/YoutubeDownloadSpeed_Tests.java
+++ b/src/test/java/com/github/kiulian/downloader/YoutubeDownloadSpeed_Tests.java
@@ -105,7 +105,6 @@ public class YoutubeDownloadSpeed_Tests extends TestUtils {
         File outputFile = new File(outDir, video.details().title() + "_" + (isByPart ? "bypart" : "straight") + format.itag().id() + "." + format.extension().value());
         try (OutputStream os = new FileOutputStream(outputFile)) {
             Method method = isByPart ? byPartMethod : straightMethod;
-            method.setAccessible(true);
             method.invoke(video, format, os, listener);
             listener.onFinished(outputFile);
             return outputFile;

--- a/src/test/java/com/github/kiulian/downloader/YoutubePlaylistExtractor_Tests.java
+++ b/src/test/java/com/github/kiulian/downloader/YoutubePlaylistExtractor_Tests.java
@@ -40,6 +40,13 @@ public class YoutubePlaylistExtractor_Tests extends YoutubePlaylistTest {
                     "Howard Shore-The Ruins of Dale", "willburowgh", true);
             testVideo(getVideo(playlist, 207),
                     "Dragon-sickness", "Howard Shore - Topic", true);
+            
+            String author = "willburowgh";
+            List<PlaylistVideoDetails> videos = playlist.findVideos(video -> video.author().equals(author));
+            assertFalse(videos.isEmpty(), "filtered videos shoud not be empty");
+            videos.forEach(video -> {
+                assertEquals(author, video.author(), "author should be " + author);
+            });
         });
     }
 
@@ -74,7 +81,7 @@ public class YoutubePlaylistExtractor_Tests extends YoutubePlaylistTest {
     }
 
     @Test
-    @DisplayName("getPlaylist should throws exception for unavailable video")
+    @DisplayName("getPlaylist should throw exception for unavailable playlist")
     void getPlaylist_Unavailable_ThrowsException() {
         assertThrows(YoutubeException.BadPageException.class, () -> {
             getPlaylist("12345678901");

--- a/src/test/java/com/github/kiulian/downloader/YoutubeVideoExtractor_Tests.java
+++ b/src/test/java/com/github/kiulian/downloader/YoutubeVideoExtractor_Tests.java
@@ -3,9 +3,7 @@ package com.github.kiulian.downloader;
 import com.github.kiulian.downloader.model.Extension;
 import com.github.kiulian.downloader.model.VideoDetails;
 import com.github.kiulian.downloader.model.YoutubeVideo;
-import com.github.kiulian.downloader.model.formats.AudioVideoFormat;
-import com.github.kiulian.downloader.model.formats.Format;
-import com.github.kiulian.downloader.model.formats.VideoFormat;
+import com.github.kiulian.downloader.model.formats.*;
 import com.github.kiulian.downloader.model.quality.AudioQuality;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -124,11 +122,19 @@ public class YoutubeVideoExtractor_Tests {
             assertNotNull(format.url(), "url should not be null");
 
             assertTrue(isReachable(format.url()), "url should be reachable");
+            
+            int maxBitrate = 100_000; 
+            formats = video.findFormats(f -> f instanceof AudioFormat && f.bitrate() < maxBitrate);
+            assertFalse(formats.isEmpty(), "filtered formats should not be empty");
+            formats.forEach(f -> {
+                assertTrue(f instanceof AudioFormat, "format should be audio");
+                assertTrue(f.bitrate() < maxBitrate, "format bitrate should be < " + maxBitrate);
+            });
         });
     }
 
     @Test
-    @DisplayName("getVideo should throws exception for unavailable video")
+    @DisplayName("getVideo should throw exception for unavailable video")
     void getVideo_Unavailable_ThrowsException() {
         YoutubeDownloader downloader = new YoutubeDownloader();
         String unavailableVideoId = "12345678901";
@@ -145,12 +151,12 @@ public class YoutubeVideoExtractor_Tests {
         String videoId = "SmM0653YvXU";
 
         assertThrows(YoutubeException.CipherException.class, () -> {
-            YoutubeVideo video = downloader.getVideo(videoId);
+            downloader.getVideo(videoId);
         }, "getVideo should throw CipherException if initial function patterns has wrong priority");
 
         downloader.addCipherFunctionPattern(0, "(?:\\b|[^a-zA-Z0-9$])([a-zA-Z0-9$]{2})\\s*=\\s*function\\(\\s*a\\s*\\)\\s*\\{\\s*a\\s*=\\s*a\\.split\\(\\s*\"\"\\s*\\)");
         assertDoesNotThrow(() -> {
-            YoutubeVideo video = downloader.getVideo(videoId);
+            downloader.getVideo(videoId);
         }, "getVideo should not throw exception if initial function patterns has correct priority");
     }
 


### PR DESCRIPTION
Implements #48 Faster downloads: "adaptive" formats (audio or video only) are downloaded part by part.
Audio formats are parsed again.
Calls to the stream API are removed (avoid problems with Android).