### PR TITLE
Add public overload of download that takes an OutputStream

### DIFF
--- a/src/main/java/com/github/kiulian/downloader/model/YoutubeVideo.java
+++ b/src/main/java/com/github/kiulian/downloader/model/YoutubeVideo.java
@@ -141,6 +141,14 @@ public class YoutubeVideo {
         return find;
     }
 
+    public void download(final Format format, final OutputStream os, final OnYoutubeDownloadListener listener) throws IOException {
+        if (format.isAdaptive() && format.contentLength() != null) {
+            downloadByPart(format, os, listener);
+        } else {
+            downloadStraight(format, os, listener);
+        }
+    }
+
     public File download(Format format, File outDir) throws IOException, YoutubeException {
         return download(format, outDir, videoDetails.title());
     }
@@ -195,11 +203,7 @@ public class YoutubeVideo {
         OutputStream os = null;
         try {
             os = new FileOutputStream(outputFile);
-            if (format.isAdaptive() && format.contentLength() != null) {
-                downloadByPart(format, os, listener);
-            } else {
-                downloadStraight(format, os, listener);
-            }
+            download(format, os, listener);
             if (listener != null) {
                 listener.onFinished(outputFile);
             }

--- a/src/test/java/com/github/kiulian/downloader/YoutubeDownloader_Tests.java
+++ b/src/test/java/com/github/kiulian/downloader/YoutubeDownloader_Tests.java
@@ -10,7 +10,9 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
+import java.io.ByteArrayOutputStream;
 import java.io.File;
+import java.io.IOException;
 import java.time.Duration;
 import java.util.List;
 import java.util.concurrent.CancellationException;
@@ -24,6 +26,21 @@ import static org.mockito.Mockito.*;
 
 @DisplayName("Tests downloading youtube videos")
 class YoutubeDownloader_Tests {
+
+    @Test
+    @DisplayName("download video sync in-memory to a stream should be successful")
+    void downloadVideo_Sync_Stream_Success() throws YoutubeException, IOException {
+        YoutubeDownloader downloader = new YoutubeDownloader();
+        YoutubeVideo video = downloader.getVideo(ME_AT_THE_ZOO_ID);
+        Format format = video.findFormatByItag(18);
+        assertNotNull(format, "findFormatByItag should return not null format");
+        assertTrue(isReachable(format.url()), "url should be reachable");
+        try (ByteArrayOutputStream os = new ByteArrayOutputStream()) {
+            video.download(format, os, null);
+            byte[] outputBytes = os.toByteArray();
+            assertTrue(outputBytes.length > 0, "OutputStream should have some content");
+        }
+    }
 
     @Test
     @DisplayName("download video sync should be successful")


### PR DESCRIPTION
Allows users of the library to operate on the data in-memory without writing to disk.

#77