### PR TITLE
Added synchronization in DelegatedCipherFactory

### DIFF
--- a/src/main/java/com/github/kiulian/downloader/parser/ParserImpl.java
+++ b/src/main/java/com/github/kiulian/downloader/parser/ParserImpl.java
@@ -48,9 +48,11 @@ public class ParserImpl implements Parser {
 
         @Override
         public Cipher createCipher(String jsUrl) throws YoutubeException {
-            if (jsUrl == null)
-                return lastCipher;
-            return lastCipher = factory.createCipher(jsUrl);
+            synchronized (factory){
+                if (jsUrl == null)
+                    return lastCipher;
+                return lastCipher = factory.createCipher(jsUrl);
+            }
 
         }
 
@@ -65,7 +67,9 @@ public class ParserImpl implements Parser {
         }
 
         Cipher getLastCipher() {
-            return lastCipher;
+            synchronized (factory){
+                return lastCipher;
+            }
         }
 
         void invalidateLastCipher() {


### PR DESCRIPTION
I looked through the code and most of it seems to be intrinsically thread-safe, but that's not the case for the CipherFactory. I am assuming the downloader is intended to be thread-safe considering it provides logic for asynchronous requests, but it fails in this particular place. For it to be thread-safe without synchronization here, the CipherFactory has to not cache the ciphers it makes, which would be pretty inefficient in this case.