### PR TITLE
Non-invasive Slf4J support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.github.ikiulian</groupId>
     <artifactId>java-youtube-downloader</artifactId>
-    <version>3.2.8</version>
+    <version>3.3.0</version>
 
     <name>Java youtube video downloader</name>
     <description>Java parser for retrieving youtube video meta info</description>
@@ -62,6 +62,18 @@
             <groupId>com.alibaba</groupId>
             <artifactId>fastjson</artifactId>
             <version>1.2.83</version>
+        </dependency>
+
+        <!-- logging -->
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>2.0.9</version>
+        </dependency>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <version>1.5.13</version>
         </dependency>
 
     </dependencies>

--- a/src/main/java/com/github/kiulian/downloader/model/videos/formats/Format.java
+++ b/src/main/java/com/github/kiulian/downloader/model/videos/formats/Format.java
@@ -1,12 +1,13 @@
 package com.github.kiulian.downloader.model.videos.formats;
 
-
-
-
 import com.alibaba.fastjson.JSONObject;
 import com.github.kiulian.downloader.model.Extension;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public abstract class Format {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(Format.class);
 
     public static final String AUDIO = "audio";
     public static final String VIDEO = "video";
@@ -32,7 +33,7 @@ public abstract class Format {
         try {
             itag = Itag.valueOf("i" + json.getInteger("itag"));
         } catch (IllegalArgumentException e) {
-            e.printStackTrace();
+            LOGGER.error("Format init failed", e);
             itag = Itag.unknown;
             itag.setId(json.getIntValue("itag"));
         }


### PR DESCRIPTION
Add a non-invasive Slf4J logging support to stop spamming with errors into the standard error stream.

This allows for log filtering from the logback files if necessary.

```xml
<configuration>
    <logger name="com.github.kiulian.downloader.parser.ParserImpl" level="OFF" additivity="false"/>
</configuration>
```